### PR TITLE
output Gremlin compatible tokens for boolean

### DIFF
--- a/src/Gremlin.Net.Extensions/GraphTraversalExtensions.cs
+++ b/src/Gremlin.Net.Extensions/GraphTraversalExtensions.cs
@@ -94,6 +94,11 @@ namespace Gremlin.Net.Extensions
                 return $"'{Regex.Replace(a, @"[^\w\s-]", "")}'";
             }
 
+            if (arg is bool b)
+            {
+                return b ? "true" : "false";
+            }
+
             if (arg.GetType().GetProperties().Where(x => x.CanRead).Any(x => x.Name == "EnumValue"))
             {
                 return arg.GetType().GetProperty("EnumValue")?.GetValue(arg)?.ToString();

--- a/test/Gremlin.Net.Extensions.Tests/GraphTraversalExtensionsTests.cs
+++ b/test/Gremlin.Net.Extensions.Tests/GraphTraversalExtensionsTests.cs
@@ -167,5 +167,13 @@ namespace Gremlin.Net.Extensions.Tests
             query.Arguments.Should().BeEquivalentTo(expectedArguments);
 
         }
+
+        [Fact]
+        public void TestToGremlinQueryBooleanTranslation()
+        {
+            var query = _g.V("customer").ValueMap<string, object>(true).ToGremlinQuery();
+
+            query.ToString().Should().Be("g.V('customer').valueMap(true)");
+        }
     }
 }


### PR DESCRIPTION
Outputs lowercase tokens `true` and `false for Boolean arguments.  The CLR defines uppercase values for `Boolean.TrueString` and `Boolean.FalseString`, which is in conflict with the Gremlin expected values.