### PR TITLE
Adding support for using arguments mapped to properties with the same name

### DIFF
--- a/src/Gremlin.Net.Extensions/GraphTraversalExtensions.cs
+++ b/src/Gremlin.Net.Extensions/GraphTraversalExtensions.cs
@@ -21,6 +21,7 @@ namespace Gremlin.Net.Extensions
 
             var arguments = new Dictionary<string, object>();
             var first = true;
+            var stepIndex = 0;
 
             foreach (var step in traversal.Bytecode.StepInstructions)
             {
@@ -56,19 +57,28 @@ namespace Gremlin.Net.Extensions
                     }
                     else
                     {
-                        if (step.OperatorName == "property" || 
+                        if (step.OperatorName == "property" ||
                             (step.OperatorName == "has" && step.Arguments.Last() is string))
                         {
-                            var (key, value) = ((string)step.Arguments.First(), (object)step.Arguments.Last());
+                            var (argName, value) = ((string)step.Arguments.First(), (object)step.Arguments.Last());
+
+                            var key = argName;
 
                             if (innerArgIndex.HasValue)
                             {
                                 key = $"{key}_{innerArgIndex.Value}";
                             }
 
+                            var index = 1;
+
+                            while (arguments.ContainsKey(key))
+                            {
+                                key = $"{argName}_{++index}";
+                            }
+
                             arguments.Add(key, value);
 
-                            builder.Append($"'{step.Arguments.First()}', {key}");
+                            builder.Append($"'{argName}', {key}");
                         }
                         else
                         {
@@ -80,6 +90,7 @@ namespace Gremlin.Net.Extensions
                 }
 
                 builder.Append(")");
+                stepIndex++;
             }
 
             return new GremlinQuery(builder, arguments);


### PR DESCRIPTION
A simple traversal across multiple vertices or edges where a commonly used property name, such as "name", could not be done before as adding to the dictionary containing the arguments resulted in a key conflict. This change utilizes an index for any given key value to uniquely identify each argument. That way, you can have the following query:

```
g.V('person')
.has('name', 'Thomas')
.out('friend')
.has('name', 'Mary')
.out('parent')
.has('name', 'Steve')
```
Translates internally to the following argument-based query:

```
g.V('person').has('name', name).out('friend').has('name', name_2).out('parent').has('name', name_3)
```

Where the argument dictionary looks like

```
var args = new Dictionary<string, object>
            {
                ["name"] = "Thomas",
                ["name_2"] = "Mary",
                ["name_3"] = "Steve"
            }
```

I left the first instance of the argument name as-is so that all existing tests and expectations of the resulting query are the same. This appeared to work fine when done as a gremlin traverasl nested in another, but at the "top-level" it blows up with the exception.